### PR TITLE
Missing MessageToolbar iOS 7

### DIFF
--- a/Code/Controllers/ATLBaseConversationViewController.m
+++ b/Code/Controllers/ATLBaseConversationViewController.m
@@ -70,6 +70,7 @@ static CGFloat const ATLMaxScrollDistanceFromBottom = 150;
     // An apparent system bug causes a view controller to not be deallocated
     // if the view controller's own inputAccessoryView property is used.
     self.view.inputAccessoryView = self.messageInputToolbar;
+    [self.messageInputToolbar sizeToFit];
 
     // Add typing indicator
     self.typingIndicatorController = [[ATLTypingIndicatorViewController alloc] init];


### PR DESCRIPTION
Fixed up an issue where the toolbar was missing
